### PR TITLE
Fix Rollup resolve plugin settings

### DIFF
--- a/.yarn/sdks/prettier/package.json
+++ b/.yarn/sdks/prettier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier",
-  "version": "2.3.1-pnpify",
+  "version": "2.3.2-pnpify",
   "main": "./index.js",
   "type": "commonjs"
 }

--- a/core/errors.ts
+++ b/core/errors.ts
@@ -1,0 +1,12 @@
+/* SPDX-FileCopyrightText: 2020-present Kriasoft <hello@kriasoft.com> */
+/* SPDX-License-Identifier: MIT */
+
+export class HttpError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    Object.setPrototypeOf(this, Error.prototype);
+  }
+}

--- a/core/index.ts
+++ b/core/index.ts
@@ -1,0 +1,4 @@
+/* SPDX-FileCopyrightText: 2020-present Kriasoft <hello@kriasoft.com> */
+/* SPDX-License-Identifier: MIT */
+
+export { HttpError } from "./errors";

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "husky": "^6.0.0",
     "jest": "^27.0.5",
     "minimist": "^1.2.5",
-    "prettier": "^2.3.1",
+    "prettier": "^2.3.2",
     "rollup": "^2.52.3",
     "typescript": "^4.3.4"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,9 @@ const config = {
     format: "cjs",
   },
   plugins: [
-    resolve(),
+    resolve({
+      extensions: [".ts", ".tsx", ".mjs", ".js", ".json", ".node"],
+    }),
     babel({
       extensions: [".js", ".mjs", ".ts", ".tsx"],
       babelHelpers: "bundled",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,7 @@
     // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
     // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
-    // "noImplicitOverride": true,                  /* Ensure overriding members in derived classes are marked with an 'override' modifier. */
+    "noImplicitOverride": true,                  /* Ensure overriding members in derived classes are marked with an 'override' modifier. */
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
 
     /* Module Resolution Options */

--- a/yarn.lock
+++ b/yarn.lock
@@ -6585,12 +6585,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "prettier@npm:2.3.1"
+"prettier@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "prettier@npm:2.3.2"
   bin:
     prettier: bin-prettier.js
-  checksum: 3b37731ff7150feecf19736c77c790e7e276b404ac9af81cbaf87cfecefc48ef9a864f34c2a5caf5955378b8f2525984b8611703a0d9c1f052b4cfa6eb35899f
+  checksum: 17ce5784ac67621c292df58e2da60b2ee150c2d6aebea22a6ad9e52fcd6a5e66c349d0a8436ea3bd8ff9d778920a5f68000d7625b74f43558718a49755aa5259
   languageName: node
   linkType: hard
 
@@ -8076,7 +8076,7 @@ typescript@^4.3.4:
     husky: ^6.0.0
     jest: ^27.0.5
     minimist: ^1.2.5
-    prettier: ^2.3.1
+    prettier: ^2.3.2
     rollup: ^2.52.3
     typescript: ^4.3.4
   languageName: unknown


### PR DESCRIPTION
- Fix `resolve` plugin settings in `rollup.config.js`
- Add `HttpError` class
- Bump Prettier to the latest version