### PR TITLE
refactor: Switch from Service Worker to ES Modules syntax

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,21 +1,15 @@
 /* SPDX-FileCopyrightText: 2020-present Kriasoft */
 /* SPDX-License-Identifier: MIT */
 
-async function handleRequest(req: Request): Promise<Response> {
-  const url = new URL(req.url);
+import { handleError } from "core";
 
-  url.protocol = "https:";
-  url.hostname = "us-central-example.cloudfunctions.net";
+export default {
+  fetch: handleError((req) => {
+    const url = new URL(req.url);
 
-  return fetch(url.toString(), req);
-}
+    url.protocol = "https:";
+    url.hostname = "swapi.dev";
 
-function handleError(err: Error): Response {
-  return new Response(JSON.stringify({ error: err.message }), { status: 500 });
-}
-
-addEventListener("fetch", function (event) {
-  event.respondWith(handleRequest(event.request).catch(handleError));
-});
-
-export {};
+    return fetch(url.toString(), req);
+  }),
+} as ExportedHandler;

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -4,7 +4,6 @@
 name = "$APP_NAME-api"
 type = "javascript"
 compatibility_date = "2022-02-19"
-build = { command = "", upload = { format = "service-worker" } }
 
 account_id = "$CLOUDFLARE_ACCOUNT_ID"
 zone_id = "$CLOUDFLARE_ZONE_ID"
@@ -16,3 +15,15 @@ routes = [
 
 [vars]
 APP_ENV = "$APP_ENV"
+
+[build]
+command = ""
+
+[build.upload]
+format = "modules"
+dir = "./dist/api"
+main = "./index.js"
+
+[[build.upload.rules]]
+type = "ESModule"
+globs = ["**/*.js"]

--- a/core/errors.ts
+++ b/core/errors.ts
@@ -1,12 +1,15 @@
 /* SPDX-FileCopyrightText: 2020-present Kriasoft */
 /* SPDX-License-Identifier: MIT */
 
-export class HttpError extends Error {
-  readonly status: number;
-
-  constructor(status: number, message: string) {
-    super(message);
-    this.status = status;
-    Object.setPrototypeOf(this, Error.prototype);
-  }
+export function handleError<Env = unknown>(
+  handler: ExportedHandlerFetchHandler<Env>
+): ExportedHandlerFetchHandler<Env> {
+  return function (req, res, ctx) {
+    try {
+      return handler(req, res, ctx);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Application error";
+      return new Response(message, { status: 500 });
+    }
+  };
 }

--- a/core/index.ts
+++ b/core/index.ts
@@ -1,5 +1,5 @@
 /* SPDX-FileCopyrightText: 2020-present Kriasoft */
 /* SPDX-License-Identifier: MIT */
 
-export { HttpError } from "./errors.js";
+export { handleError } from "./errors.js";
 export { transform } from "./transform.js";

--- a/package.json
+++ b/package.json
@@ -2,13 +2,12 @@
   "name": "app",
   "version": "0.0.0",
   "private": true,
-  "main": "./dist/site/index.js",
   "type": "module",
   "packageManager": "yarn@4.0.0-rc.6",
   "workspaces": [
+    "api",
     "core",
-    "site",
-    "workers"
+    "site"
   ],
   "scripts": {
     "postinstall": "husky install && node ./scripts/postinstall.js",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -14,19 +14,10 @@ process.env.CF_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN;
 const cwd = join(__dirname, "../dist");
 
 for (const name of globbySync("*", { cwd, onlyDirectories: true })) {
-  const pkgFile = join(__dirname, "../package.json");
-  const pkg = await readFile(pkgFile, "utf-8");
   const configFile = join(cwd, name, "wrangler.toml");
   const config = await readFile(configFile, "utf-8");
 
   try {
-    // Update the package.json->main field required by Wrangler CLI
-    await writeFile(
-      pkgFile,
-      pkg.replace(/^(\s*"main":\s*)".*?"/m, `$1"./dist/${name}/index.js"`),
-      "utf-8"
-    );
-
     // Inject environment variables into `dist/{name}/wrangler.toml`
     await writeFile(
       configFile,
@@ -52,8 +43,6 @@ for (const name of globbySync("*", { cwd, onlyDirectories: true })) {
       ).on("close", (code) => (code === 0 ? resolve() : reject()));
     });
   } finally {
-    // Restore the original files: package.json, wrangler.toml
-    await writeFile(pkgFile, pkg, "utf-8");
     await writeFile(configFile, config, "utf-8");
   }
 }

--- a/site/index.ts
+++ b/site/index.ts
@@ -1,21 +1,17 @@
 /* SPDX-FileCopyrightText: 2020-present Kriasoft */
 /* SPDX-License-Identifier: MIT */
 
-async function handleRequest(req: Request): Promise<Response> {
-  const url = new URL(req.url);
+import { handleError } from "core";
 
-  url.protocol = "https:";
-  url.hostname = "welcome.developers.workers.dev";
+export default {
+  fetch: handleError((req) => {
+    const url = new URL(req.url);
 
-  return fetch(url.toString(), req);
-}
+    url.protocol = "https:";
+    url.hostname = "welcome.developers.workers.dev";
 
-function handleError(err: Error): Response {
-  return new Response(err.message, { status: 500 });
-}
+    return new Response("OK", { status: 200 });
 
-addEventListener("fetch", function (event) {
-  event.respondWith(handleRequest(event.request).catch(handleError));
-});
-
-export {};
+    return fetch(url.toString(), req);
+  }),
+} as ExportedHandler;

--- a/site/wrangler.toml
+++ b/site/wrangler.toml
@@ -4,7 +4,6 @@
 name = "$APP_NAME-site"
 type = "javascript"
 compatibility_date = "2022-02-19"
-build = { command = "", upload = { format = "service-worker" } }
 
 account_id = "$CLOUDFLARE_ACCOUNT_ID"
 zone_id = "$CLOUDFLARE_ZONE_ID"
@@ -13,3 +12,15 @@ route = "$APP_HOSTNAME/*"
 
 [vars]
 APP_ENV = "$APP_ENV"
+
+[build]
+command = ""
+
+[build.upload]
+format = "modules"
+dir = "./dist/site"
+main = "./index.js"
+
+[[build.upload.rules]]
+type = "ESModule"
+globs = ["**/*.js"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1362,6 +1362,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/kv-asset-handler@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@cloudflare/kv-asset-handler@npm:0.2.0"
+  dependencies:
+    mime: "npm:^3.0.0"
+  checksum: ce1ea9525387f65d4eec9337abc32a9ddcc0d3b790ed3dbbfb5c8affd1e71e0de9c99689f87cf31553af4df2c05d08a019daa0e13734f96f058282116a8ac54d
+  languageName: node
+  linkType: hard
+
 "@cloudflare/workers-types@npm:^3.11.0":
   version: 3.11.0
   resolution: "@cloudflare/workers-types@npm:3.11.0"
@@ -2646,6 +2655,15 @@ __metadata:
   checksum: b9266228a3e1406086ece57c20f9cbfc9755375218697c79a71fba9245ad23a672687314422e97753fbb3bccd245d7c76974d7c15ba513386b499de6ba002300
   languageName: node
   linkType: hard
+
+"api@workspace:api":
+  version: 0.0.0-use.local
+  resolution: "api@workspace:api"
+  dependencies:
+    "@cloudflare/kv-asset-handler": "npm:^0.2.0"
+    core: "workspace:*"
+  languageName: unknown
+  linkType: soft
 
 "app@workspace:.":
   version: 0.0.0-use.local
@@ -5613,6 +5631,15 @@ __metadata:
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 51e3b38d1b1b83da082f7c29042bcb22036101346394696b7643ef5da27ebf6bf71643bd45225ee75e4ea2836213780efc8c3dcd2055c84b49eb0afc061419d0
+  languageName: node
+  linkType: hard
+
+"mime@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mime@npm:3.0.0"
+  bin:
+    mime: cli.js
+  checksum: b00613ec79e1f14586c970b6651afca77947f972eca6086ccb614c2b7a1a899d0ec38c6f4418370ecb9d0cebeb4ad300999b6b7f2dcbeaf40f9e0d55874b6c81
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### `BEFORE`

```ts
import { handleError } from "core";

async function handleRequest(req: Request): Promise<Response> {
  const url = new URL(req.url);

  url.protocol = "https:";
  url.hostname = "welcome.developers.workers.dev";

  return fetch(url.toString(), req);
}

addEventListener("fetch", function (event) {
  event.respondWith(handleRequest(event.request).catch(handleError));
});
```

#### `AFTER`

```ts
import { handleError } from "core";

export default {
  fetch: handleError((req) => {
    const url = new URL(req.url);

    url.protocol = "https:";
    url.hostname = "welcome.developers.workers.dev";

    return fetch(url.toString(), req);
  }),
} as ExportedHandler;
```

#### `wrangler.toml`

```toml
name = "$APP_NAME"
type = "javascript"
compatibility_date = "2022-02-19"

account_id = "$CLOUDFLARE_ACCOUNT_ID"
zone_id = "$CLOUDFLARE_ZONE_ID"

route = "$APP_HOSTNAME/*"

[vars]
APP_ENV = "$APP_ENV"

[build]
command = ""

[build.upload]
format = "modules"
dir = "./dist/site"
main = "./index.js"

[[build.upload.rules]]
type = "ESModule"
globs = ["**/*.js"]
```

Note that environment variables are being loaded from the `/env/.<envName>.env` files when you run:

```bash
yarn build
yarn deploy [--env #0]         # E.g. `yarn deploy --env=prod`, OR `yarn deploy --env=test`
```

#### References

* https://blog.cloudflare.com/workers-javascript-modules/
* https://developers.cloudflare.com/workers/wrangler/module-system/