### PR TITLE
refactor: Improvements to `yarn cf` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint --cache --report-unused-disable-directives .",
     "test": "node --experimental-vm-modules $(yarn bin jest)",
     "build": "rollup -c --environment BABEL_ENV:production",
+    "cf": "zx ./scripts/cf.js",
     "deploy": "yarn workspaces foreach run deploy",
     "api:build": "rollup -c --environment TARGET:api,BABEL_ENV:production",
     "api:deploy": "yarn api:build && zx ./scripts/cf.js api publish",


### PR DESCRIPTION
Wrangler CLI wrapper improvements, handling some edge cases.

```bash
$ yarn cf api --help
$ yarn cf site --help
```

```bash
# Publish to a CF Worker named "example-site"; website URL - https://example.com/
$ yarn cf site publish --env=prod

# Publish to a CF Worker named "example-site-test"; website URL - https://test.example.com/
$ yarn cf site publish --env=test

# Publish to a CF Worker named "example-site-test-23"; website URL - https://23-test.example.com/
$ yarn cf site publish --env=test --version=23
```

The name of the published CF Worker script follows the same convention as in [Relay Starter Kit](https://github.com/kriasoft/relay-starter-kit).