### PR TITLE
feat: Add API proxy configuration to `yarn start`

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -5,23 +5,37 @@ import { getAuthToken } from "web-auth-library/google";
 
 export default {
   async fetch(req, env) {
-    const url = new URL(req.url);
+    try {
+      const url = new URL(req.url);
 
-    // An example of communicating with Google Cloud (GCP)
-    if (url.pathname === "/api/projects") {
-      const token = await getAuthToken({
-        credentials: env.GOOGLE_CLOUD_CREDENTIALS,
-        scope: "https://www.googleapis.com/auth/cloud-platform",
-      });
+      // An example of communicating with Google Cloud (GCP)
+      if (url.pathname === "/api/projects") {
+        const token = await getAuthToken({
+          credentials: env.GOOGLE_CLOUD_CREDENTIALS,
+          scope: "https://www.googleapis.com/auth/cloud-platform",
+        });
 
-      return fetch("https://cloudresourcemanager.googleapis.com/v1/projects", {
-        headers: { authorization: `Bearer ${token.accessToken}` },
-      });
+        return fetch(
+          "https://cloudresourcemanager.googleapis.com/v1/projects",
+          {
+            headers: { authorization: `Bearer ${token.accessToken}` },
+          }
+        );
+      }
+
+      // An example of forwarding HTTP requests to a 3rd party API
+      const targetUrl = `https://swapi.dev${url.pathname}${url.search}`;
+      const targetReq = new Request(targetUrl, req);
+      targetReq.headers.set("Accept", "application/json");
+      return await fetch(targetReq);
+    } catch (err) {
+      return Response.json(
+        {
+          message: (err as Error).message ?? "Application Error",
+          stack: env.APP_ENV === "prod" ? undefined : (err as Error).stack,
+        },
+        { status: 500 }
+      );
     }
-
-    // An example of forwarding HTTP requests to a 3rd party API
-    url.protocol = "https:";
-    url.hostname = "swapi.dev";
-    return await fetch(url.toString(), req);
   },
 } as ExportedHandler<Env>;

--- a/app/core/App.tsx
+++ b/app/core/App.tsx
@@ -1,0 +1,36 @@
+/* SPDX-FileCopyrightText: 2020-present Kriasoft */
+/* SPDX-License-Identifier: MIT */
+
+import * as React from "react";
+
+export function App(): JSX.Element {
+  const [data, setData] = React.useState();
+
+  React.useEffect(() => {
+    (async () => {
+      const res = await fetch("/api/people/1");
+      const body = await res.json();
+      setData(body);
+    })();
+  }, []);
+
+  return (
+    <React.Fragment>
+      <h2>Welcome to Cloudflare Starter Kit!</h2>
+
+      <p>
+        <a href="https://github.com/kriasoft/cloudflare-starter-kit">
+          https://github.com/kriasoft/cloudflare-starter-kit
+        </a>
+      </p>
+
+      <p>
+        Fetching <code>/api/people/1</code> (as an example):
+      </p>
+
+      <pre>
+        <code>{data && JSON.stringify(data, null, "  ")}</code>
+      </pre>
+    </React.Fragment>
+  );
+}

--- a/app/core/index.ts
+++ b/app/core/index.ts
@@ -1,0 +1,4 @@
+/* SPDX-FileCopyrightText: 2020-present Kriasoft */
+/* SPDX-License-Identifier: MIT */
+
+export { App } from "./App.js";

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -3,11 +3,12 @@
 
 import * as React from "react";
 import { createRoot } from "react-dom/client";
+import { App } from "./core/index.js";
 
 const root = createRoot(document.getElementById("root") as HTMLElement);
 
 root.render(
   <React.StrictMode>
-    <p>Welcome to Cloudflare Starer Kit!</p>
+    <App />
   </React.StrictMode>
 );

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "postinstall": "husky install && node ./scripts/postinstall.js",
-    "start": "zx ./scripts/start.js",
+    "start": "yarn node --experimental-vm-modules $(yarn bin zx) ./scripts/start.js",
     "cf": "zx ./scripts/cf.js",
     "tsc": "yarn workspaces foreach run tsc",
     "lint": "eslint --cache --report-unused-disable-directives .",
@@ -77,6 +77,7 @@
     "pretty-bytes": "^6.0.0",
     "rollup": "^2.75.6",
     "typescript": "^4.7.4",
+    "vite": "^2.9.12",
     "whatwg-fetch": "^3.6.2",
     "wrangler": "^2.0.14",
     "zx": "^7.0.0"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -47,7 +47,7 @@ export default globbySync(["*/wrangler.toml"])
             await del(`${name}/dist/**`);
           },
           generateBundle(options, bundle) {
-            if (!process.argv.includes("--silent")) {
+            if (!process.argv.includes("--silent") && !this.meta.watchMode) {
               const file = basename(options.file);
               const size = bundle[file].code.length;
               const prettySize = chalk.green(prettyBytes(size));

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,10 +1,88 @@
 /* SPDX-FileCopyrightText: 2020-present Kriasoft */
 /* SPDX-License-Identifier: MIT */
 
-import { execa } from "execa";
-import path from "node:path";
+import envars from "envars";
+import { Miniflare } from "miniflare";
+import * as rollup from "rollup";
+import vite from "vite";
+import { $, argv, chalk } from "zx";
 
-await execa("yarn", ["vite"], {
-  stdio: "inherit",
-  cwd: path.resolve(__dirname, "../app"),
+process.env.TARGET = "api";
+const { default: apiConfig } = await import("../rollup.config.mjs");
+
+// Configure the Cloudflare Workers server
+const mf = new Miniflare({
+  scriptPath: "api/dist/index.js",
+  modules: true,
+  bindings: envars.config(),
+  sourceMap: true,
 });
+
+// Launch the API compiler in "watch" mode
+const api = await new Promise((resolve, reject) => {
+  let initialized = false;
+  rollup.watch(apiConfig).on("event", (event) => {
+    if (event.code === "END") {
+      if (initialized) {
+        mf.reload();
+      } else {
+        initialized = true;
+        mf.startServer()
+          .then(async (server) => {
+            await mf.startScheduler();
+            resolve(server);
+          })
+          .catch(reject);
+      }
+    } else if (event.code === "ERROR") {
+      if (initialized) {
+        initialized = true;
+        reject(event.error);
+      } else {
+        console.log(event.error);
+      }
+    }
+  });
+});
+
+console.clear();
+console.log("");
+
+console.log(
+  [
+    `${chalk.gray("Application")}: ${chalk.greenBright($.env.APP_NAME)}`,
+    `${chalk.gray("environment")}: ${chalk.greenBright($.env.APP_ENV)}`,
+  ].join(", ")
+);
+
+console.log("");
+
+// Launch the web application (front-end) server
+const app = await vite.createServer({
+  root: "app",
+  base: argv.base,
+  logLevel: argv.logLevel ?? argv.l,
+  clearScreen: argv.clearScreen,
+  optimizeDeps: {
+    force: argv.force,
+  },
+  server: {
+    host: argv.host,
+    port: argv.port,
+    https: argv.https,
+    open: argv.open,
+    cors: argv.cors,
+    strictPort: argv.strictPort,
+    proxy: {
+      "/api": {
+        target: `http://localhost:${api.address().port}`,
+        changeOrigin: true,
+      },
+    },
+  },
+});
+
+await app.listen();
+app.printUrls();
+
+console.log("");

--- a/yarn.lock
+++ b/yarn.lock
@@ -4513,6 +4513,7 @@ __metadata:
     pretty-bytes: "npm:^6.0.0"
     rollup: "npm:^2.75.6"
     typescript: "npm:^4.7.4"
+    vite: "npm:^2.9.12"
     whatwg-fetch: "npm:^3.6.2"
     wrangler: "npm:^2.0.14"
     zx: "npm:^7.0.0"


### PR DESCRIPTION
Now when you launch the front-end app via `yarn start`, it exposes (Cloudflare Worker) API endpoint on `http://localhost:3000/api`.

The front-end app can call API without a need of setting CORS:

```ts
const res = await fetch("/api/people/1");
const data = await res.json();
```